### PR TITLE
Added missing pthread linking to CMakeLists.txt in examples

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -16,5 +16,5 @@ set(src
 )
 add_executable(${PROJECT_NAME} ${src})
 
-target_link_libraries(${PROJECT_NAME} distance_transform)
+target_link_libraries(${PROJECT_NAME} distance_transform pthread)
 set_distance_transform_source_files_properties()


### PR DESCRIPTION
Without the pthread linked, the main.cpp build fails. Fixed in this commit. 